### PR TITLE
Use more generic `#!/usr/bin/env bash` instead of `#!/bin/bash`

### DIFF
--- a/skills/browsing/test-e2e.sh
+++ b/skills/browsing/test-e2e.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # End-to-end test: Navigate, extract, and verify multi-step workflow
 
 echo "=== End-to-End Workflow Test ==="

--- a/skills/browsing/test-extract.sh
+++ b/skills/browsing/test-extract.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Test extraction commands
 
 echo "=== Navigate to example.com ==="

--- a/skills/browsing/test-interact.sh
+++ b/skills/browsing/test-interact.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Test interaction commands
 
 echo "=== Navigate to search page ==="

--- a/skills/browsing/test-navigate.sh
+++ b/skills/browsing/test-navigate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Test navigation commands
 
 echo "=== Navigate to google.com ==="

--- a/skills/browsing/test-raw.sh
+++ b/skills/browsing/test-raw.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Manual test: requires Chrome running with --remote-debugging-port=9222
 
 # Get first tab's WebSocket URL

--- a/skills/browsing/test-tabs.sh
+++ b/skills/browsing/test-tabs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Test tab management commands
 
 echo "=== Listing tabs ==="

--- a/skills/browsing/test-wait.sh
+++ b/skills/browsing/test-wait.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Test wait commands
 
 echo "=== Navigate to example.com ==="


### PR DESCRIPTION
Use more generic `#!/usr/bin/env bash` instead of `#!/bin/bash`.
`#!/usr/bin/env bash` does not work with nixos.

<!-- Provide a brief summary of your changes -->

## Motivation and Context
`#!/usr/bin/env bash` does not work with nixos.


## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved compatibility and portability of multiple test scripts through enhanced system environment configurations. These enhancements ensure reliable execution across different systems and operating environments, reducing potential compatibility issues while maintaining all existing functionality and optimizing cross-platform support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->