### PR TITLE
Add initializeSession stub for MCP startup

### DIFF
--- a/skills/browsing/chrome-ws-lib.js
+++ b/skills/browsing/chrome-ws-lib.js
@@ -561,6 +561,13 @@ async function startChrome() {
   await new Promise(resolve => setTimeout(resolve, 2000));
 }
 
+// No-op session initializer used by the MCP entrypoint. Added by Codex to
+// match mcp/src/index.ts expectations and avoid startup crashes when the
+// module is required from an ESM bundle.
+function initializeSession() {
+  return;
+}
+
 module.exports = {
   getTabs,
   newTab,
@@ -576,5 +583,6 @@ module.exports = {
   waitForElement,
   waitForText,
   screenshot,
-  startChrome
+  startChrome,
+  initializeSession
 };


### PR DESCRIPTION
## Summary\n- add a no-op initializeSession export in chrome-ws-lib to match mcp/src/index.ts expectations\n- prevents startup crash (TypeError: initializeSession is not a function) when running the MCP server\n\n## Testing\n- node mcp/dist/index.js --headless\n\nAuthored by Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated module initialization configuration to support additional integration scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->