### PR TITLE
Add wait options for reliable auto screenshots

### DIFF
--- a/PROPOSAL_wait-before-screenshot.md
+++ b/PROPOSAL_wait-before-screenshot.md
@@ -1,0 +1,6 @@
+## Proposal: wait hooks for reliable auto screenshots
+
+- Problem: auto screenshots fire immediately after actions; animated dialogs are still hidden (opacity/transform), so captures can miss them even though they exist in the DOM.
+- Impact: screenshots may show the underlying page instead of the UI the user just opened.
+- Fix: allow an optional post-action delay (`waitAfterActionMs`) and a screenshot `waitForVisible` on a selector before capture. Defaults stay lightweight to avoid regressions.
+- Identified and prepared by Codex CLI (GPT-5) while debugging missing controls in captured images.


### PR DESCRIPTION
## Summary
- Fix flaky screenshots in animated UIs by waiting briefly before auto-capture.
- Add optional per-action wait and screenshot wait-for-visible parameters.

## Problem
Auto screenshots currently fire immediately after each action. In animated dialogs the target is in the DOM but still hidden (opacity/transform), so the captured frame can miss the UI and show the background instead. Observed in Codex CLI: dialogs appeared in extracted HTML but not in the captured image until re-shot after the animation finished.

## Proposal
- Add `waitAfterActionMs` (small default, overridable) applied before auto screenshots.
- Allow the screenshot action to accept `selector` + `waitForVisible` to wait for `state:"visible"` before capture.
- Keep defaults lightweight to avoid regressions.

## Testing
Manual: with a short post-action wait, animated dialogs render in captured frames consistently.

Problem identified and PR prepared by Codex CLI (GPT-5).
