### PR TITLE
Fix: include chrome-ws support files in npm package

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,8 @@ Files included in npm package (from root `package.json`):
 "files": [
   "mcp/dist/",
   "skills/browsing/chrome-ws-lib.js",
+  "skills/browsing/host-override.js",
+  "skills/browsing/package.json",
   "README.md",
   "CHANGELOG.md"
 ]

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   "files": [
     "mcp/dist/",
     "skills/browsing/chrome-ws-lib.js",
+    "skills/browsing/host-override.js",
+    "skills/browsing/package.json",
     "README.md",
     "CHANGELOG.md"
   ],


### PR DESCRIPTION
## Summary
- include `skills/browsing/host-override.js` and `skills/browsing/package.json` in published files so `chrome-ws-lib.js` loads under ESM packaging
- document the updated npm file list

## Test plan
- [x] `npm pack --ignore-scripts --dry-run --json /home/user/code/extern/superpowers-chrome`
- [x] `npm pack --ignore-scripts` + `node --input-type=module -e "import { createRequire } from 'module'; const require = createRequire(import.meta.url); require('<packed>/skills/browsing/chrome-ws-lib.js');"`
- [x] `codex -c mcp_servers.chrome.command=\"node\" -c mcp_servers.chrome.args=[\"<packed>/mcp/dist/index.js\"] exec "Use the browser to open https://example.com and report the page title."`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package distribution to include browsing skill files, expanding the contents available to package consumers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->