### PR TITLE
Fix npm package to include chrome-ws support files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,8 @@ Files included in npm package (from root `package.json`):
 "files": [
   "mcp/dist/",
   "skills/browsing/chrome-ws-lib.js",
+  "skills/browsing/host-override.js",
+  "skills/browsing/package.json",
   "README.md",
   "CHANGELOG.md"
 ]

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   "files": [
     "mcp/dist/",
     "skills/browsing/chrome-ws-lib.js",
+    "skills/browsing/host-override.js",
+    "skills/browsing/package.json",
     "README.md",
     "CHANGELOG.md"
   ],


### PR DESCRIPTION
## Problem\n\n`npx github:obra/superpowers-chrome` fails to start the MCP server with:\n\n`ReferenceError: require is not defined in ES module scope` (from `skills/browsing/chrome-ws-lib.js`).\n\nThe root package is "type": "module" and the npm package didn't include `skills/browsing/package.json`, so Node treats `chrome-ws-lib.js` as ESM even though it uses `require(...)`. The missing `host-override.js` also breaks the library when it is loaded.\n\n## Fix\n\nShip the CJS scope marker and dependency by adding these to the npm `files` list:\n- `skills/browsing/package.json` (keeps `chrome-ws-lib.js` in CJS scope)\n- `skills/browsing/host-override.js` (required by the library)\n\nAlso updates the CLAUDE.md snippet to match.\n\n## Why this is necessary\n\nWithout these files, any consumer using `npx github:...` (or an npm pack) hits the ESM/CJS mismatch and the MCP server won't boot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added browsing skill files to the package distribution list.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->