### PR TITLE
docs: Add Linux/WSL2 DISPLAY configuration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ cd ~/.claude/plugins/cache/superpowers-chrome/skills/browsing
 
 **Windows tip:** The tooling defaults to `127.0.0.1:9222` for DevTools traffic. Override via `CHROME_WS_HOST` / `CHROME_WS_PORT` if you forward Chrome elsewhere.
 
+**Linux/WSL2 tip:** For headed mode (visible browser), the MCP server needs the `DISPLAY` environment variable. If `show_browser` doesn't work, configure `"env": {"DISPLAY": ":0"}` in your MCP server config. See [mcp/README.md](mcp/README.md#linuxwsl2-headed-mode) for details.
+
 ## Windows Verification (November 7, 2025)
 
 - `node skills/browsing/chrome-ws start` launched Chrome with remote debugging enabled on a fresh Windows 11 Pro install.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -137,6 +137,50 @@ npm run dev
 
 Chrome is bound to `127.0.0.1:9222` by default to avoid hostname resolution issues on recent Windows builds. Override with `CHROME_WS_HOST` / `CHROME_WS_PORT` if you expose DevTools on a different interface.
 
+### Linux/WSL2 Headed Mode
+
+The MCP server auto-detects display availability by checking the `DISPLAY` or `WAYLAND_DISPLAY` environment variables. When running in headed mode (visible browser window), Chrome needs these variables to connect to your display server.
+
+**Problem:** In WSL2 or when MCP servers are spawned by applications that don't inherit your shell environment, these variables may not be set, causing `show_browser` to fail silently or Chrome to crash.
+
+**Solution:** Explicitly configure the `DISPLAY` environment variable in your MCP server configuration:
+
+```json
+{
+  "mcpServers": {
+    "chrome": {
+      "command": "node",
+      "args": ["/path/to/mcp/dist/index.js"],
+      "env": {
+        "DISPLAY": ":0"
+      }
+    }
+  }
+}
+```
+
+For Claude Code, add this to `~/.claude/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "plugin_superpowers-chrome_chrome": {
+      "command": "node",
+      "args": ["${HOME}/.claude/plugins/cache/superpowers-marketplace/superpowers-chrome/VERSION/mcp/dist/index.js"],
+      "env": {
+        "DISPLAY": ":0"
+      }
+    }
+  }
+}
+```
+
+Replace `VERSION` with your installed version (e.g., `1.6.1`).
+
+**Note:** After updating the configuration, restart Claude Code or your MCP client for the changes to take effect.
+
+**Verifying your display:** Run `echo $DISPLAY` in your terminal. Common values are `:0` for WSLg or a local X server, or `:10.0` for SSH X forwarding.
+
 ## Architecture
 
 ```


### PR DESCRIPTION
## Summary

- Document how to configure the `DISPLAY` environment variable for headed browser mode in Linux/WSL2 environments
- The MCP server auto-detects display availability via `DISPLAY`/`WAYLAND_DISPLAY` env vars, but these may not be inherited when spawned by Claude Code or other MCP clients
- Adds detailed troubleshooting section to `mcp/README.md` with example configurations
- Adds brief tip to main `README.md` with link to detailed docs

## Test plan

- [x] Verified the issue exists on WSL2 (Ubuntu on Windows)
- [x] Confirmed that adding `"env": {"DISPLAY": ":0"}` to mcp.json resolves the issue
- [x] Tested that Chrome launches in headed mode after configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring Linux/WSL2 headed mode, including DISPLAY environment variable setup
  * Provided example configurations and verification steps for enabling headed mode support on Linux and WSL2 systems

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->