### PR TITLE
feat: add CHROME_WS_BROWSER env var to override browser executable

### DIFF
--- a/skills/browsing/COMMANDLINE-USAGE.md
+++ b/skills/browsing/COMMANDLINE-USAGE.md
@@ -15,6 +15,27 @@ chmod +x chrome-ws
 
 Chrome starts with `--remote-debugging-port=9222` and separate profile in `/tmp/chrome-debug` (or `C:\temp\chrome-debug` on Windows).
 
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CHROME_WS_BROWSER` | (auto-detect) | Path to browser executable. Overrides auto-detection. |
+| `CHROME_WS_HOST` | `127.0.0.1` | Debug host address |
+| `CHROME_WS_PORT` | `9222` | Debug port number |
+
+**Examples:**
+
+```bash
+# Force Chromium instead of Chrome
+CHROME_WS_BROWSER=/usr/bin/chromium ./chrome-ws start
+
+# Use custom port
+CHROME_WS_PORT=9333 ./chrome-ws start
+
+# Use Brave browser
+CHROME_WS_BROWSER="/usr/bin/brave-browser" ./chrome-ws start
+```
+
 ## Command Reference
 
 **Setup:**

--- a/skills/browsing/chrome-ws
+++ b/skills/browsing/chrome-ws
@@ -247,8 +247,8 @@ if (command === 'start') {
     process.exit(1);
   }
 
-  // Find Chrome executable
-  const chromePath = paths.find(p => existsSync(p));
+  // Find Chrome executable (CHROME_WS_BROWSER env var overrides auto-detection)
+  const chromePath = process.env.CHROME_WS_BROWSER || paths.find(p => existsSync(p));
 
   if (!chromePath) {
     console.error('Chrome not found. Searched:');


### PR DESCRIPTION
AI Assistant:

## Summary

Allow users to force a specific browser executable instead of relying on auto-detection. This is useful when:

* Multiple browsers are installed but user prefers a specific one
* Chrome is present but Chromium is preferred
* Using alternative Chromium-based browsers (Brave, Edge, etc.)

## Changes

* Add `CHROME_WS_BROWSER` environment variable check before path auto-detection in `chrome-ws`
* Document all environment variables (`CHROME_WS_BROWSER`, `CHROME_WS_HOST`, `CHROME_WS_PORT`) in `COMMANDLINE-USAGE.md`
* Include usage examples for Chromium and Brave browsers

## Usage

```bash
# Force Chromium instead of Chrome
CHROME_WS_BROWSER=/usr/bin/chromium ./chrome-ws start

# Use Brave browser
CHROME_WS_BROWSER="/usr/bin/brave-browser" ./chrome-ws start

# Use custom port
CHROME_WS_PORT=9333 ./chrome-ws start
```

## Test plan

* Verified `CHROME_WS_BROWSER=/usr/bin/chromium ./chrome-ws start` launches Chromium
* Confirmed auto-detection still works when env var is not set

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment variables now available to override Chrome path detection and configure connection settings.

* **Documentation**
  * Added documentation detailing configurable environment variables with defaults and usage examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->