### PR TITLE
fix: update version metadata to 1.8.0 and document all MCP actions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "superpowers-chrome",
       "description": "Direct Chrome DevTools Protocol access. Control Chrome via MCP tool or CLI skill. Auto-starts browser, zero dependencies.",
-      "version": "1.6.2",
+      "version": "1.8.0",
       "source": "./",
       "author": {
         "name": "Jesse Vincent",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "superpowers-chrome",
-  "version": "1.6.1",
-  "description": "BETA: VERY LIGHTLY TESTED - Direct Chrome DevTools Protocol access via 'browsing' skill. Skill mode (17 CLI commands) + MCP mode (single use_browser tool). Zero dependencies, auto-starts Chrome.",
+  "version": "1.8.0",
+  "description": "Direct Chrome DevTools Protocol access via 'browsing' skill. Skill mode (17 CLI commands) + MCP mode (single use_browser tool). Zero dependencies, auto-starts Chrome.",
   "author": {
     "name": "Jesse Vincent",
     "email": "jesse@fsck.com"

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -4,7 +4,7 @@ Ultra-lightweight MCP server for Chrome DevTools Protocol via `chrome-ws`.
 
 ## Features
 
-- **Single Tool**: `use_browser` with 13 actions
+- **Single Tool**: `use_browser` with 23 actions
 - **XPath & CSS**: Selectors support both CSS and XPath (auto-detected)
 - **Auto-start**: Chrome launches automatically on first use
 - **Zero Config**: No setup required, works out of the box
@@ -65,6 +65,16 @@ The `use_browser` tool accepts these parameters:
 | `new_tab` | Create new tab | - | - |
 | `close_tab` | Close tab | - | - |
 | `list_tabs` | List all tabs | - | - |
+| `show_browser` | Show browser window | - | - |
+| `hide_browser` | Hide browser window | - | - |
+| `browser_mode` | Get browser visibility state | - | - |
+| `set_profile` | Switch browser profile | - | Profile name |
+| `get_profile` | Get current profile name | - | - |
+| `keyboard_press` | Send keyboard key | - | Key name (e.g. 'Enter') |
+| `set_viewport` | Set viewport dimensions | - | JSON: `{"width": N, "height": N}` |
+| `clear_viewport` | Reset viewport to default | - | - |
+| `get_viewport` | Get current viewport size | - | - |
+| `clear_cookies` | Clear all browser cookies | - | - |
 
 ### Examples
 


### PR DESCRIPTION
## Summary
- Update `plugin.json` version from `1.6.1` to `1.8.0`
- Update `marketplace.json` version from `1.6.2` to `1.8.0`
- Remove outdated "BETA: VERY LIGHTLY TESTED" label from plugin description
- Add 10 missing actions to the MCP README actions table (added in v1.7.0 and v1.8.0)
- Update action count from "13 actions" to "23 actions"

## Test plan
- [x] Verified `package.json` is at `1.8.0`
- [x] Verified `CHANGELOG.md` documents all actions listed
- [x] Cross-referenced MCP source for action names

🤖 Generated with [Claude Code](https://claude.com/claude-code)