### PR TITLE
fix: guard against non-array response in resolveWsUrl

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "superpowers-chrome",
       "description": "Direct Chrome DevTools Protocol access. Control Chrome via MCP tool or CLI skill. Auto-starts browser, zero dependencies.",
-      "version": "1.6.2",
+      "version": "1.8.0",
       "source": "./",
       "author": {
         "name": "Jesse Vincent",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "superpowers-chrome",
-  "version": "1.6.1",
-  "description": "BETA: VERY LIGHTLY TESTED - Direct Chrome DevTools Protocol access via 'browsing' skill. Skill mode (17 CLI commands) + MCP mode (single use_browser tool). Zero dependencies, auto-starts Chrome.",
+  "version": "1.8.0",
+  "description": "Direct Chrome DevTools Protocol access via 'browsing' skill. Skill mode (17 CLI commands) + MCP mode (single use_browser tool). Zero dependencies, auto-starts Chrome.",
   "author": {
     "name": "Jesse Vincent",
     "email": "jesse@fsck.com"

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -4,7 +4,7 @@ Ultra-lightweight MCP server for Chrome DevTools Protocol via `chrome-ws`.
 
 ## Features
 
-- **Single Tool**: `use_browser` with 13 actions
+- **Single Tool**: `use_browser` with 23 actions
 - **XPath & CSS**: Selectors support both CSS and XPath (auto-detected)
 - **Auto-start**: Chrome launches automatically on first use
 - **Zero Config**: No setup required, works out of the box
@@ -65,6 +65,16 @@ The `use_browser` tool accepts these parameters:
 | `new_tab` | Create new tab | - | - |
 | `close_tab` | Close tab | - | - |
 | `list_tabs` | List all tabs | - | - |
+| `show_browser` | Show browser window | - | - |
+| `hide_browser` | Hide browser window | - | - |
+| `browser_mode` | Get browser visibility state | - | - |
+| `set_profile` | Switch browser profile | - | Profile name |
+| `get_profile` | Get current profile name | - | - |
+| `keyboard_press` | Send keyboard key | - | Key name (e.g. 'Enter') |
+| `set_viewport` | Set viewport dimensions | - | JSON: `{"width": N, "height": N}` |
+| `clear_viewport` | Reset viewport to default | - | - |
+| `get_viewport` | Get current viewport size | - | - |
+| `clear_cookies` | Clear all browser cookies | - | - |
 
 ### Examples
 

--- a/skills/browsing/chrome-ws-lib.js
+++ b/skills/browsing/chrome-ws-lib.js
@@ -332,7 +332,7 @@ async function resolveWsUrl(wsUrlOrIndex) {
   const index = typeof wsUrlOrIndex === 'number' ? wsUrlOrIndex : parseInt(wsUrlOrIndex);
   if (!isNaN(index)) {
     const tabs = await chromeHttp('/json');
-    const pageTabs = tabs.filter(t => t.type === 'page');
+    const pageTabs = Array.isArray(tabs) ? tabs.filter(t => t.type === 'page') : [];
 
     // Auto-create tab if none exist (similar to auto-start Chrome behavior)
     if (pageTabs.length === 0) {


### PR DESCRIPTION
## Summary
- Add `Array.isArray()` guard in `resolveWsUrl()` before calling `.filter()` on the `/json` endpoint response

## Why
When Chrome's `/json` CDP endpoint returns a non-array value (during startup, on error, or with certain Chrome configurations), `tabs.filter()` crashes with `TypeError: tabs.filter is not a function`. 

The `getTabs()` function at line 517 already has this exact guard — this applies the same pattern to `resolveWsUrl()` at line 335.

## How
```diff
- const pageTabs = tabs.filter(t => t.type === 'page');
+ const pageTabs = Array.isArray(tabs) ? tabs.filter(t => t.type === 'page') : [];
```

When `tabs` is not an array, `pageTabs` becomes `[]`, which triggers the existing auto-create-tab logic on line 338.

## Testing
- [x] macOS 15.x — reproduced by hitting the endpoint during Chrome startup
- [ ] Linux
- [ ] Windows

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)