### PR TITLE
Add NixOS Chrome path support

### DIFF
--- a/skills/browsing/chrome-ws
+++ b/skills/browsing/chrome-ws
@@ -235,6 +235,7 @@ if (command === 'start') {
     linux: [
       '/usr/bin/google-chrome',
       '/usr/bin/google-chrome-stable',
+      '/run/current-system/sw/bin/google-chrome-stable',
       '/usr/bin/chromium',
       '/usr/bin/chromium-browser'
     ],

--- a/skills/browsing/chrome-ws-lib.js
+++ b/skills/browsing/chrome-ws-lib.js
@@ -1322,6 +1322,8 @@ async function startChrome(headless = null, profileName = null, port = null) {
     ],
     linux: [
       '/usr/bin/google-chrome',
+      '/usr/bin/google-chrome-stable',
+      '/run/current-system/sw/bin/google-chrome-stable',
       '/usr/bin/chromium-browser',
       '/usr/bin/chromium'
     ],


### PR DESCRIPTION
Add /run/current-system/sw/bin/google-chrome-stable to Linux Chrome paths for NixOS compatibility. Also add missing /usr/bin/google-chrome-stable to chrome-ws-lib.js for consistency with chrome-ws.