### PR TITLE
Add: --autoConnect flag to attach to an already-running Chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the superpowers-chrome MCP project.
 
+## [Unreleased] - autoConnect to existing Chrome
+
+### Added
+- **`--autoConnect` flag**: Attach to an already-running Chrome instead of launching a new instance. Reads `DevToolsActivePort` from Chrome's user data directory to find the debugging port and WebSocket path. Requires Chrome 136+ with remote debugging enabled at `chrome://inspect/#remote-debugging`
+- **`--userDataDir=PATH` flag**: Specify Chrome's user data directory for `--autoConnect`. Defaults to the platform's standard location (`~/Library/Application Support/Google/Chrome` on macOS)
+- **CDP-based tab management**: When using `--autoConnect`, tab operations (list, create, close) go through the CDP Target domain over WebSocket instead of HTTP `/json`. This is needed because Chrome's built-in remote debugging server doesn't expose the HTTP endpoint
+- **`connectViaDevToolsActivePort()`**: New function exported from chrome-ws-lib for programmatic use
+
+---
+
 ## [1.8.0] - 2026-02-25 - Viewport Emulation, Full-Page Screenshots, and HiDPI Fix
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -93,6 +93,33 @@ Ultra-lightweight MCP server with a single `use_browser` tool. Perfect for minim
 }
 ```
 
+**Option 1c: Attach to an already-running Chrome (`--autoConnect`)**
+
+Instead of launching a new Chrome, connect to one you already have open.
+Requires Chrome 136+ with remote debugging enabled at `chrome://inspect/#remote-debugging`.
+
+```json
+{
+  "mcpServers": {
+    "chrome": {
+      "command": "npx",
+      "args": [
+        "github:obra/superpowers-chrome",
+        "--autoConnect"
+      ]
+    }
+  }
+}
+```
+
+This reads Chrome's `DevToolsActivePort` file to find the debugging port and WebSocket path.
+All tab operations go through CDP's Target domain, so no HTTP endpoint is needed.
+
+You can also point to a specific Chrome profile directory:
+```
+"--autoConnect", "--userDataDir=/path/to/chrome/profile"
+```
+
 **Option 2: Git Clone + Local Path (Current)**
 ```bash
 git clone https://github.com/obra/superpowers-chrome.git

--- a/mcp/dist/index.js
+++ b/mcp/dist/index.js
@@ -13894,6 +13894,9 @@ var forceHeadless = process.argv.includes("--headless");
 var forceHeaded = process.argv.includes("--headed");
 var portArg = process.argv.find((a) => a.startsWith("--port="));
 var explicitPort = portArg ? parseInt(portArg.split("=")[1], 10) : void 0;
+var autoConnect = process.argv.includes("--autoConnect");
+var userDataDirArg = process.argv.find((a) => a.startsWith("--userDataDir="));
+var userDataDir = userDataDirArg ? userDataDirArg.split("=").slice(1).join("=") : void 0;
 var headlessMode;
 if (forceHeadless) {
   headlessMode = true;
@@ -13957,6 +13960,15 @@ var UseBrowserParams = {
 async function ensureChromeRunning() {
   if (chromeStarted) {
     return;
+  }
+  if (autoConnect) {
+    try {
+      chromeLib.connectViaDevToolsActivePort(userDataDir);
+      chromeStarted = true;
+      return;
+    } catch (err) {
+      throw new Error(`autoConnect failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
   }
   try {
     await chromeLib.startChrome(headlessMode, void 0, explicitPort);

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -42,15 +42,20 @@ function hasDisplay(): boolean {
   }
 }
 
-// Parse command line arguments for headless mode and port
+// Parse command line arguments for headless mode, port, and autoConnect
 // --headless: Force headless mode
 // --headed: Force headed mode (will fail if no display)
 // --port=N: Use specific CDP port (overrides dynamic allocation)
+// --autoConnect: Attach to an already-running Chrome via DevToolsActivePort
+// --userDataDir=PATH: Chrome user data directory (default: platform default)
 // Default: headless if no display available, headed otherwise
 const forceHeadless = process.argv.includes('--headless');
 const forceHeaded = process.argv.includes('--headed');
 const portArg = process.argv.find(a => a.startsWith('--port='));
 const explicitPort = portArg ? parseInt(portArg.split('=')[1], 10) : undefined;
+const autoConnect = process.argv.includes('--autoConnect');
+const userDataDirArg = process.argv.find(a => a.startsWith('--userDataDir='));
+const userDataDir = userDataDirArg ? userDataDirArg.split('=').slice(1).join('=') : undefined;
 
 let headlessMode: boolean;
 if (forceHeadless) {
@@ -159,13 +164,22 @@ type UseBrowserInput = z.infer<ReturnType<typeof z.object<typeof UseBrowserParam
 
 /**
  * Ensure Chrome is running, auto-start if needed.
- * startChrome() handles meta.json discovery and reconnection to existing
- * Chrome instances, so we delegate entirely to it rather than probing
- * a potentially wrong port with getTabs() first.
+ * With --autoConnect, attaches to an existing Chrome via DevToolsActivePort
+ * instead of launching a new instance.
  */
 async function ensureChromeRunning(): Promise<void> {
   if (chromeStarted) {
     return;
+  }
+
+  if (autoConnect) {
+    try {
+      chromeLib.connectViaDevToolsActivePort(userDataDir);
+      chromeStarted = true;
+      return;
+    } catch (err) {
+      throw new Error(`autoConnect failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
   }
 
   try {

--- a/skills/browsing/chrome-ws-lib.js
+++ b/skills/browsing/chrome-ws-lib.js
@@ -26,6 +26,9 @@ const {
 // Defaults to CHROME_DEBUG_PORT (from env CHROME_WS_PORT or 9222).
 let activePort = CHROME_DEBUG_PORT;
 
+// Set by connectViaDevToolsActivePort(); triggers CDP Target domain path in getTabs/newTab/closeTab
+let browserWsEndpoint = null;
+
 // Port range for dynamic allocation (tried sequentially starting at 9222 for backward compat)
 const PORT_RANGE_START = 9222;
 const PORT_RANGE_END = 12111;
@@ -331,8 +334,7 @@ async function resolveWsUrl(wsUrlOrIndex) {
   // If it's a number (tab index), resolve it
   const index = typeof wsUrlOrIndex === 'number' ? wsUrlOrIndex : parseInt(wsUrlOrIndex);
   if (!isNaN(index)) {
-    const tabs = await chromeHttp('/json');
-    const pageTabs = tabs.filter(t => t.type === 'page');
+    const pageTabs = await getTabs();
 
     // Auto-create tab if none exist (similar to auto-start Chrome behavior)
     if (pageTabs.length === 0) {
@@ -512,9 +514,136 @@ const KEY_DEFINITIONS = {
   'Insert': { key: 'Insert', code: 'Insert', keyCode: 45 },
 };
 
+// Browser-level WS connection for CDP Target domain (autoConnect mode)
+let browserConn = null;
+
+async function getBrowserConnection() {
+  if (browserConn && browserConn.ws.isConnected()) {
+    return browserConn;
+  }
+  if (!browserWsEndpoint) {
+    throw new Error('No browser WebSocket endpoint (not in autoConnect mode)');
+  }
+
+  const ws = new WebSocketClient(browserWsEndpoint);
+  browserConn = { ws, pending: new Map(), nextId: 1 };
+
+  ws.on('message', (msg) => {
+    try {
+      const data = JSON.parse(msg);
+      if (data.id !== undefined) {
+        const p = browserConn.pending.get(data.id);
+        if (p) {
+          clearTimeout(p.timer);
+          browserConn.pending.delete(data.id);
+          data.error ? p.reject(new Error(data.error.message)) : p.resolve(data.result);
+        }
+      }
+    } catch (e) {
+      console.error('Browser CDP parse error:', e);
+    }
+  });
+
+  ws.on('close', () => { browserConn = null; });
+  ws.on('error', (err) => { console.error('Browser WS error:', err.message); });
+
+  await ws.connect();
+  return browserConn;
+}
+
+async function sendBrowserCdpCommand(method, params = {}, timeout = 10000) {
+  const conn = await getBrowserConnection();
+  const id = conn.nextId++;
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      conn.pending.delete(id);
+      reject(new Error(`Browser CDP timeout: ${method}`));
+    }, timeout);
+
+    conn.pending.set(id, { resolve, reject, timer });
+    conn.ws.send(JSON.stringify({ id, method, params }));
+  });
+}
+
+async function getTabsViaCdp() {
+  const result = await sendBrowserCdpCommand('Target.getTargets');
+  return (result.targetInfos || [])
+    .filter(t => t.type === 'page')
+    .map(t => ({
+      id: t.targetId,
+      title: t.title,
+      url: t.url,
+      type: t.type,
+      webSocketDebuggerUrl: `ws://${CHROME_DEBUG_HOST}:${activePort}/devtools/page/${t.targetId}`
+    }));
+}
+
+async function newTabViaCdp(url = 'about:blank') {
+  const result = await sendBrowserCdpCommand('Target.createTarget', { url });
+  const targetId = result.targetId;
+  return {
+    id: targetId,
+    url,
+    type: 'page',
+    webSocketDebuggerUrl: `ws://${CHROME_DEBUG_HOST}:${activePort}/devtools/page/${targetId}`
+  };
+}
+
+async function closeTabViaCdp(targetId) {
+  await sendBrowserCdpCommand('Target.closeTarget', { targetId });
+}
+
+function connectViaDevToolsActivePort(userDataDir) {
+  const fs = require('fs');
+  const path = require('path');
+  const os = require('os');
+
+  const defaultDirs = {
+    darwin: path.join(os.homedir(), 'Library', 'Application Support', 'Google', 'Chrome'),
+    win32: path.join(os.homedir(), 'AppData', 'Local', 'Google', 'Chrome', 'User Data'),
+    linux: path.join(os.homedir(), '.config', 'google-chrome')
+  };
+
+  const dataDir = userDataDir || defaultDirs[os.platform()];
+  if (!dataDir) {
+    throw new Error(`Cannot detect Chrome user data dir on ${os.platform()}`);
+  }
+
+  const portFile = path.join(dataDir, 'DevToolsActivePort');
+  let content;
+  try {
+    content = fs.readFileSync(portFile, 'utf8');
+  } catch {
+    throw new Error(
+      `No DevToolsActivePort in ${dataDir}. ` +
+      `Enable remote debugging at chrome://inspect/#remote-debugging`
+    );
+  }
+
+  const lines = content.split('\n').map(l => l.trim()).filter(Boolean);
+  if (lines.length < 2) {
+    throw new Error(`Unexpected DevToolsActivePort format: ${content.trim()}`);
+  }
+
+  const port = parseInt(lines[0], 10);
+  const wsPath = lines[1];
+  if (isNaN(port) || port <= 0 || port > 65535) {
+    throw new Error(`Bad port in DevToolsActivePort: ${lines[0]}`);
+  }
+
+  activePort = port;
+  browserWsEndpoint = `ws://${CHROME_DEBUG_HOST}:${port}${wsPath}`;
+  console.error(`Attached to existing Chrome (port: ${port}, autoConnect)`);
+  return { port, wsPath, browserWsEndpoint };
+}
+
 // API Functions
 
 async function getTabs() {
+  if (browserWsEndpoint) {
+    return getTabsViaCdp();
+  }
   const tabs = await chromeHttp('/json');
   if (!Array.isArray(tabs)) {
     return [];
@@ -528,6 +657,9 @@ async function getTabs() {
 }
 
 async function newTab(url = 'about:blank') {
+  if (browserWsEndpoint) {
+    return newTabViaCdp(url);
+  }
   const encoded = encodeURIComponent(url);
   const tab = await chromeHttp(`/json/new?${encoded}`, 'PUT');
   if (tab && typeof tab === 'object') {
@@ -538,6 +670,13 @@ async function newTab(url = 'about:blank') {
 
 async function closeTab(tabIndexOrWsUrl) {
   const wsUrl = await resolveWsUrl(tabIndexOrWsUrl);
+  if (browserWsEndpoint) {
+    const match = wsUrl.match(/\/devtools\/page\/(.+)$/);
+    if (match) {
+      await closeTabViaCdp(match[1]);
+      return;
+    }
+  }
   const tabs = await chromeHttp('/json');
   const tab = tabs.find(t => t.webSocketDebuggerUrl === wsUrl);
   if (tab) {
@@ -2381,6 +2520,7 @@ module.exports = {
 
   // Chrome lifecycle
   startChrome,
+  connectViaDevToolsActivePort,
   killChrome,
   showBrowser,
   hideBrowser,

--- a/test-auto-connect.cjs
+++ b/test-auto-connect.cjs
@@ -1,0 +1,65 @@
+/**
+ * Test: --autoConnect via DevToolsActivePort
+ *
+ * Prerequisites:
+ *   - Chrome running with remote debugging enabled (chrome://inspect/#remote-debugging)
+ *   - DevToolsActivePort file present in Chrome's user data dir
+ *
+ * Run: node test-auto-connect.cjs
+ */
+
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+
+const chromeLib = require('./skills/browsing/chrome-ws-lib.js');
+
+const defaultDirs = {
+  darwin: path.join(os.homedir(), 'Library', 'Application Support', 'Google', 'Chrome'),
+  win32: path.join(os.homedir(), 'AppData', 'Local', 'Google', 'Chrome', 'User Data'),
+  linux: path.join(os.homedir(), '.config', 'google-chrome')
+};
+
+const dataDir = defaultDirs[os.platform()];
+const portFile = path.join(dataDir, 'DevToolsActivePort');
+
+if (!fs.existsSync(portFile)) {
+  console.log('SKIP: No DevToolsActivePort found — Chrome not running with remote debugging');
+  console.log(`  Looked in: ${portFile}`);
+  console.log('  Enable at: chrome://inspect/#remote-debugging');
+  process.exit(0);
+}
+
+console.log(`Found DevToolsActivePort at ${portFile}`);
+console.log(`  Contents: ${fs.readFileSync(portFile, 'utf8').trim().replace('\n', ' | ')}`);
+
+(async () => {
+  try {
+    // Step 1: connect
+    const info = chromeLib.connectViaDevToolsActivePort();
+    console.log(`PASS: connected on port ${info.port}`);
+
+    // Step 2: list tabs
+    const tabs = await chromeLib.getTabs();
+    console.log(`PASS: getTabs returned ${tabs.length} tab(s)`);
+    for (const t of tabs) {
+      console.log(`  [${t.id.slice(0, 8)}] ${t.url}`);
+    }
+
+    // Step 3: create a tab, then close it
+    const tab = await chromeLib.newTab('about:blank');
+    console.log(`PASS: created tab ${tab.id.slice(0, 8)}`);
+
+    const tabsAfter = await chromeLib.getTabs();
+    console.log(`PASS: now ${tabsAfter.length} tab(s)`);
+
+    await chromeLib.closeTab(tabsAfter.length - 1);
+    const tabsFinal = await chromeLib.getTabs();
+    console.log(`PASS: closed tab, back to ${tabsFinal.length}`);
+
+    console.log('\nAll tests passed.');
+  } catch (err) {
+    console.error(`FAIL: ${err.message}`);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Problem

When using superpowers-chrome as an MCP server (e.g. with Claude Code), it launches
a separate Chrome instance. This means you lose access to your existing logins,
cookies, and browsing session. For tasks like reading saved Reddit posts or checking
LinkedIn analytics, you'd have to log in again in the new instance.

Chrome DevTools MCP solves this with `--autoConnect` by reading the DevToolsActivePort
file, but superpowers-chrome didn't have this option.

## Solution

Reads DevToolsActivePort from Chrome's user data directory to find the debugging port
and WebSocket path. Tab operations (list, create, close) go through CDP Target domain
over WebSocket when in this mode, since Chrome's built-in remote debugging server
doesn't expose the HTTP /json endpoint.

Requires Chrome 136+ with remote debugging enabled at chrome://inspect/#remote-debugging

No new dependencies — uses the existing WebSocket client.

## Testing

- Tested against Chrome 146 (macOS arm64) with 30 open tabs
- getTabs, newTab, closeTab all work via CDP Target domain
- Existing behavior unchanged when --autoConnect is not passed