### PR TITLE
fix: include mcp/package.json in npm files array

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "files": [
     "mcp/dist/",
+    "mcp/package.json",
     "skills/browsing/chrome-ws-lib.js",
     "skills/browsing/host-override.js",
     "skills/browsing/lib/",


### PR DESCRIPTION
The compiled `mcp/dist/index.js` references `../package.json` at runtime to read `SERVER_VERSION`. Since `mcp/package.json` was not listed in the root `files` array, npm installs excluded it, causing:

```
Error: Cannot find module '.../mcp/package.json'
```

This made the package un-runnable when installed via `npx -y github:obra/superpowers-chrome` or `npm install superpowers-chrome-mcp`.

Adding `mcp/package.json` to the files array fixes the crash on startup.