### PR TITLE
fix(cli): honor Chrome extra args on start

### DIFF
--- a/skills/browsing/chrome-ws
+++ b/skills/browsing/chrome-ws
@@ -51,6 +51,7 @@ if (command === '--version' || command === '-v') {
 
 const hostOverride = require('./host-override').createOverride();
 const { createSession } = require('./chrome-ws-lib');
+const { buildChromeArgs } = require('./lib/chrome-launcher-helpers');
 const CHROME_DEBUG_HOST = hostOverride.getHost();
 const CHROME_DEBUG_PORT = hostOverride.getPort();
 const WS_OVERRIDE_ENABLED = hostOverride.isOverrideEnabled();
@@ -326,10 +327,11 @@ if (command === 'start') {
     ? 'C:\\temp\\chrome-debug'
     : '/tmp/chrome-debug';
 
-  const chromeArgs = [
-    `--remote-debugging-port=${effectivePort}`,
-    `--user-data-dir=${userDataDir}`
-  ];
+  const chromeArgs = buildChromeArgs({
+    chosenPort: effectivePort,
+    chromeUserDataDir: userDataDir,
+    chromeHeadless: false,
+  });
 
   console.log(`Starting Chrome: ${chromePath}`);
   const chrome = spawn(chromePath, chromeArgs, {

--- a/test/cli-dispatch.test.mjs
+++ b/test/cli-dispatch.test.mjs
@@ -15,15 +15,18 @@
 import { describe, it } from 'node:test';
 import { strict as assert } from 'node:assert';
 import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI = path.join(__dirname, '..', 'skills', 'browsing', 'chrome-ws');
 
-function runCLI(args, { timeoutMs = 5000 } = {}) {
+function runCLI(args, { env = {}, timeoutMs = 5000 } = {}) {
   return spawnSync('node', [CLI, ...args], {
     encoding: 'utf8',
+    env: { ...process.env, ...env },
     timeout: timeoutMs,
   });
 }
@@ -71,5 +74,41 @@ describe('chrome-ws CLI dispatch', () => {
       /Usage: chrome-ws raw </,
       'stop must not print the raw usage banner'
     );
+  });
+
+  it('start uses the shared Chrome arg builder and honors CHROME_EXTRA_ARGS', () => {
+    const dir = path.join(tmpdir(), `chrome-ws-cli-args-${process.pid}-${Date.now()}`);
+    mkdirSync(dir, { recursive: true });
+    const fakeChrome = path.join(dir, 'fake-chrome');
+    const argsFile = path.join(dir, 'args.json');
+
+    writeFileSync(fakeChrome, `#!/usr/bin/env node
+const fs = require('node:fs');
+fs.writeFileSync(process.env.FAKE_CHROME_ARGS_FILE, JSON.stringify(process.argv.slice(2)));
+`, { mode: 0o755 });
+
+    try {
+      const r = runCLI(['--port=49217', 'start'], {
+        env: {
+          CHROME_WS_BROWSER: fakeChrome,
+          CHROME_EXTRA_ARGS: '--headless=new --disable-gpu --flag-from-env',
+          FAKE_CHROME_ARGS_FILE: argsFile,
+        },
+        timeoutMs: 5000,
+      });
+
+      assert.equal(r.status, 1, 'fake Chrome never opens the debug port, so start should fail');
+      assert.ok(existsSync(argsFile), 'fake Chrome should have been spawned');
+
+      const args = JSON.parse(readFileSync(argsFile, 'utf8'));
+      assert.ok(args.includes('--remote-debugging-port=49217'));
+      assert.ok(args.some(a => a.startsWith('--user-data-dir=')));
+      assert.ok(args.includes('--no-first-run'), 'baseline shared-helper flag should be present');
+      assert.ok(args.includes('--headless=new'), 'CHROME_EXTRA_ARGS should be appended');
+      assert.ok(args.includes('--disable-gpu'), 'CHROME_EXTRA_ARGS should support multiple flags');
+      assert.ok(args.includes('--flag-from-env'), 'CHROME_EXTRA_ARGS should reach CLI start');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
Fixes #35.

## Problem
`chrome-ws start` built its Chrome launch args inline, so it ignored the documented `CHROME_EXTRA_ARGS` environment variable. That meant headless/root Linux users could not pass flags such as `--headless=new` or `--disable-gpu` through the CLI start path, even though the MCP/library launch path already honored those flags.

## Change
- Reuse the existing `buildChromeArgs()` helper in `chrome-ws start`.
- Keep CLI start headed by default with `chromeHeadless: false`.
- Add a CLI regression test that launches a fake browser binary and inspects the actual argv passed to the child process.

## Verification
- Red check: temporarily restored the old inline-args path; the new CLI regression test failed because the shared-helper/env flags were absent.
- `node --test test/cli-dispatch.test.mjs` passed: 5/5.
- `npm test` passed: lint clean, bundle fresh, 435/435 tests passing.

## Review
Anupam Chugh reviewed the complete diff in chat before submission. The diff is scoped to two files and does not add dependencies or unrelated refactors.

## Notes
This repo currently has `main` as its default branch and no remote `dev` branch, so this PR targets `main`.