### PR TITLE
fix: honor CHROME_WS_BROWSER in the MCP-tool Chrome-launch path

### DIFF
--- a/skills/browsing/lib/chrome-process.js
+++ b/skills/browsing/lib/chrome-process.js
@@ -154,7 +154,11 @@ function attachChromeProcess({ state, chromeHttp, getTabs, newTab }) {
     // CHROME_WS_BROWSER overrides auto-detection (documented in README.md /
     // COMMANDLINE-USAGE.md, already honored by the chrome-ws CLI) — this path
     // is what the MCP `use_browser` tool actually runs, so it needs the same.
+    // A stale or mistyped override would otherwise be spawned as-is, surfacing as
+    // an opaque "Chrome did not become ready" timeout, so fall back to
+    // auto-detection when the path does not exist.
     let chromePath = process.env.CHROME_WS_BROWSER;
+    if (chromePath && !existsSync(chromePath)) chromePath = null;
     if (!chromePath) {
       for (const path of paths) {
         if (existsSync(path)) {

--- a/skills/browsing/lib/chrome-process.js
+++ b/skills/browsing/lib/chrome-process.js
@@ -151,11 +151,16 @@ function attachChromeProcess({ state, chromeHttp, getTabs, newTab }) {
     const platform = os.platform();
     const paths = chromePaths[platform] || [];
 
-    let chromePath = null;
-    for (const path of paths) {
-      if (existsSync(path)) {
-        chromePath = path;
-        break;
+    // CHROME_WS_BROWSER overrides auto-detection (documented in README.md /
+    // COMMANDLINE-USAGE.md, already honored by the chrome-ws CLI) — this path
+    // is what the MCP `use_browser` tool actually runs, so it needs the same.
+    let chromePath = process.env.CHROME_WS_BROWSER;
+    if (!chromePath) {
+      for (const path of paths) {
+        if (existsSync(path)) {
+          chromePath = path;
+          break;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

- `chrome-process.js` — the module `mcp/dist/index.js` actually requires at runtime (`chrome-ws-lib.js` → `chrome-process.js`) — never read `CHROME_WS_BROWSER`, even though README.md / COMMANDLINE-USAGE.md document it as overriding auto-detection, and the standalone `chrome-ws` CLI already honors it. So the env var silently did nothing for anyone driving Chrome through the MCP `use_browser` tool.
- This PR makes the MCP path check the env var first, matching the CLI's existing behavior, before falling back to the hardcoded per-platform path list.

Related: #40, which also covers a second, separate issue (no bundle-id isolation between automation Chrome and the user's daily Chrome on macOS) that I've left out of this PR since it's more of a design discussion than a bug fix — happy to follow up there once there's a preferred direction.

## Test plan

- `npm test` (lint + bundle-freshness check + full `node --test` suite): 434/434 passing, including the real-Chrome smoke test, unmodified.
- Manually verified the resolution logic picks up `CHROME_WS_BROWSER` when set to an existing path, and falls through to the existing auto-detect list when unset — no behavior change for existing users who don't set it.